### PR TITLE
Replace wildcard imports with explicit imports

### DIFF
--- a/ShowFilledPreview.glyphsReporter/Contents/Info.plist
+++ b/ShowFilledPreview.glyphsReporter/Contents/Info.plist
@@ -13,9 +13,9 @@
 	<key>CFBundleName</key>
 	<string>ShowFilledPreview</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.0.5</string>
+	<string>2.0.6</string>
 	<key>CFBundleVersion</key>
-	<string>15</string>
+	<string>16</string>
 	<key>UpdateFeedURL</key>
 	<string>https://raw.githubusercontent.com/mekkablue/ShowFilledPreview/master/ShowFilledPreview.glyphsReporter/Contents/Info.plist</string>
 	<key>productPageURL</key>

--- a/ShowFilledPreview.glyphsReporter/Contents/Resources/plugin.py
+++ b/ShowFilledPreview.glyphsReporter/Contents/Resources/plugin.py
@@ -10,7 +10,10 @@ from __future__ import division, print_function, unicode_literals
 #
 ###########################################################################################################
 
-from GlyphsApp.plugins import *
+import objc
+from GlyphsApp import Glyphs
+from GlyphsApp.plugins import ReporterPlugin
+from AppKit import NSColor
 
 class ShowFilledPreview(ReporterPlugin):
 	@objc.python_method


### PR DESCRIPTION
Follows the recent import-cleanup pattern applied across the Glyphs plug-in repos: replace wildcard imports with explicit ones.

### Changes
- `from GlyphsApp.plugins import *` → explicit:
  - `from GlyphsApp.plugins import ReporterPlugin`
  - `from GlyphsApp import Glyphs`
  - `from AppKit import NSColor`
  - `import objc` (the `@objc.python_method` decorator was relying on the wildcard re-export)
- Version bump: `CFBundleVersion` 15 → 16, `CFBundleShortVersionString` 2.0.5 → 2.0.6

No behavioural change; only the imports are made explicit.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bs2JtfNiM4z5Duepf74nqX)_